### PR TITLE
Feat : 버튼 클릭 시 API 요청 및 상태 반영 구현

### DIFF
--- a/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
@@ -11,14 +11,33 @@ import LoadingSpinner from "@/components/loading/LoadingSpinner";
 import {MentoringTeamLeader, MentoringTeamMember, ProjectMember} from "@/app/team/_type/teamPageMember";
 import {transformTeamData} from "@/app/team/_service/teamMemberService";
 
+interface Params {
+  member_type: string;
+  page_type: string;
+  team_id: string;
+}
+
 export interface TeamMemberTables {
   type: "MEMBER" | "LEADER";
   data: ProjectMember[];
+  params?: {
+    member_type: string;
+    page_type: string;
+    team_id: string;
+  } | undefined;
 }
 
 const Page = () => {
+  const params = (useParams() as unknown) as Params;
+
+  // 기본값 처리
+  const normalizedParams = {
+    member_type: params.member_type ?? "leader",
+    page_type: params.page_type ?? "default",
+    team_id: params.team_id ?? "0",
+  };
+
   // 데이터 패칭
-  const params = useParams();
   const {data, error, isLoading} = useQuery({
     queryKey: ["members"],
     queryFn: () =>
@@ -44,6 +63,7 @@ const Page = () => {
           <MemberTables
               type="MEMBER"
               data={members}
+              params={normalizedParams}
           />
         </MemberTableWrapper>
 
@@ -56,6 +76,7 @@ const Page = () => {
               <MemberTables
                   type="LEADER"
                   data={members}
+                  params={normalizedParams}
               />
             </MemberTableWrapper>
         )}

--- a/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
@@ -9,7 +9,7 @@ import {useParams} from "next/navigation";
 import {team} from "@/app/team/_data/member";
 import LoadingSpinner from "@/components/loading/LoadingSpinner";
 import {MentoringTeamLeader, MentoringTeamMember, ProjectMember} from "@/app/team/_type/teamPageMember";
-import {transformTeamData} from "@/app/team/_service/teamPageMemberService";
+import {transformTeamData} from "@/app/team/_service/teamMemberService";
 
 export interface TeamMemberTables {
   type: "MEMBER" | "LEADER";

--- a/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
@@ -32,6 +32,7 @@ const Page = () => {
 
   // ✅ 데이터 변환
   const members = transformTeamData(data);
+  const isMemberType = params.member_type === "leader" || "owner";
 
   return (
       <>
@@ -47,7 +48,7 @@ const Page = () => {
         </MemberTableWrapper>
 
         {/* 신청 내역 리스트 (리더 전용) */}
-        {params.member_type === "LEADER" && (
+        {isMemberType && (
             <MemberTableWrapper title="신청내역">
               {/* 테이블 헤더 */}
               <MemberTableHeader tableName={team.leader}/>

--- a/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/[member_type]/page.tsx
@@ -8,7 +8,8 @@ import MemberTables from "@/app/team/_components/MemberTables";
 import {useParams} from "next/navigation";
 import {team} from "@/app/team/_data/member";
 import LoadingSpinner from "@/components/loading/LoadingSpinner";
-import {ProjectMember} from "@/app/team/_type/teamPageMember";
+import {MentoringTeamLeader, MentoringTeamMember, ProjectMember} from "@/app/team/_type/teamPageMember";
+import {transformTeamData} from "@/app/team/_service/teamPageMemberService";
 
 export interface TeamMemberTables {
   type: "MEMBER" | "LEADER";
@@ -19,22 +20,19 @@ const Page = () => {
   // 데이터 패칭
   const params = useParams();
   const {data, error, isLoading} = useQuery({
-    queryKey: ["page"],
-    queryFn: () => fetchTeamPageData(String(params.page_type), String(params.team_id), "member")
+    queryKey: ["members"],
+    queryFn: () =>
+        fetchTeamPageData<MentoringTeamLeader | MentoringTeamMember | ProjectMember[]>(
+            String(params.page_type), String(params.team_id), "member"),
   });
 
   // 로딩 및 에러처리
   if (isLoading) return <LoadingSpinner/>;
   // if (error) return <div>Error fetching data</div>;
 
+  // ✅ 데이터 변환
+  const members = transformTeamData(data);
 
-
-  /*
-   * 멘토링팀 멤버 및 지원자 조회 (/mentoring/teams/{team_id}/status
-   * 프로젝트 팀 지원자 조회 (/project/team/{team_id}/participation
-   * 만약 데이터가 멘토링이면 ? 프로젝트면 ? => 데이터 바인딩 함수 생성
-   * 타입가드
-   */
   return (
       <>
         {/* 팀원 리스트 */}
@@ -44,7 +42,7 @@ const Page = () => {
           {/* 테이블 데이터 */}
           <MemberTables
               type="MEMBER"
-              data={data}
+              data={members}
           />
         </MemberTableWrapper>
 
@@ -56,7 +54,7 @@ const Page = () => {
               {/* 테이블 데이터 */}
               <MemberTables
                   type="LEADER"
-                  data={data}
+                  data={members}
               />
             </MemberTableWrapper>
         )}

--- a/src/app/team/[page_type]/[team_id]/(member)/info/_components/TeamPageInfo.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/info/_components/TeamPageInfo.tsx
@@ -32,8 +32,6 @@ const TeamPageInfo: React.FC<Props> = (
   const team_id = params?.team_id;
   const encodedData = encodeURIComponent(JSON.stringify(infoData));
   const infoEditHref = `/form/edit/${page_type}/${team_id}?page=${encodedData}`
-  console.log(infoData);
-  console.log(encodedData);
 
   return (
       <div className="h-full p-4 border rounded bg-white overflow-y-auto">

--- a/src/app/team/[page_type]/[team_id]/(member)/layout.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/layout.tsx
@@ -25,11 +25,12 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({children}) => {
   // data?.authority 값에 따라 다른 네비게이션 구성
   // 예 : page_type 이 project 면 /project/{project_team_id}/info ...
   const firstPath = `/team/${params.page_type}/${params.team_id}`;
+  const isUserAuthority = data?.authority === "LEADER" || data?.userRole === "OWNER";
+  const leaderNavigation = {label: "멤버 및 지원자 현황", path: `${firstPath}/leader`};
+  const memberNavigation = {label: "멤버", path: `${firstPath}/member`};
   const teamPagePaths = [
     {label: "팀 소개", path: `${firstPath}/info`},
-    data?.authority === "LEADER"
-      ? {label: "멤버 및 지원자 현황", path: `${firstPath}/leader`}
-      : {label: "멤버", path: `${firstPath}/member`},
+    isUserAuthority ? leaderNavigation : memberNavigation,
     {label: "작성한 게시글", path: `${firstPath}/post`},
   ];
 

--- a/src/app/team/[page_type]/[team_id]/(member)/layout.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/layout.tsx
@@ -12,22 +12,15 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({children}) => {
   const path = usePathname();
   const currentPath = path.split("/").pop();
 
-  // 항상 useQuery 를 호출하고, "info"가 아닐 때는 enabled 옵션으로 비활성화
-  const queryClient = useQueryClient();
-  const queryFn = fetchTeamPageData<TeamPageInfo>(String(params.page_type), String(params.team_id), "info");
-
   const {data, error, isLoading} = useQuery<TeamPageInfo>({
     queryKey: ["teamInfo", params.page_type, params.team_id],
-    queryFn: () => queryFn,
+    queryFn: () => fetchTeamPageData<TeamPageInfo>(String(params.page_type), String(params.team_id), "info"),
     enabled: currentPath === "info" && !!params.page_type && !!params.team_id,
   });
 
   // 로딩 및 에러처리
   if (isLoading) return <LoadingSpinner/>;
   if (error) return <div>Error fetching data</div>;
-
-  // 데이터 캐싱
-  queryClient.setQueryData(["teamInfo", params.page_type, params.team_id], data);
 
   // data?.authority 값에 따라 다른 네비게이션 구성
   // 예 : page_type 이 project 면 /project/{project_team_id}/info ...

--- a/src/app/team/[page_type]/[team_id]/(member)/post/page.tsx
+++ b/src/app/team/[page_type]/[team_id]/(member)/post/page.tsx
@@ -14,7 +14,7 @@ const Page = () => {
   const queryFn = fetchTeamPageData(String(params.page_type), String(params.team_id), "posts");
 
   const {data, error, isLoading} = useQuery({
-    queryKey: ["page"],
+    queryKey: ["posts"],
     queryFn: () => queryFn
   });
 
@@ -30,7 +30,7 @@ const Page = () => {
   // 데이터가 없을 경우
   if (!data || (Array.isArray(data) && data.length === 0)) {
     return (
-        <div className="text-center">
+        <div className="h-full flex flex-col justify-center items-center">
           <p>게시물이 없습니다.</p>
           <Link href={`/create/${params.page_type}/post`} className="text-blue-400">
             게시글 작성하러 가기

--- a/src/app/team/_components/MemberTables.tsx
+++ b/src/app/team/_components/MemberTables.tsx
@@ -78,9 +78,15 @@ const MemberTables: React.FC<TeamMemberTables> = ({type, data}) => {
 
               return (
                   <div key={idx} className="flex text-center border-b last:border-none p-2 text-sm">
-                    <div className={columnWidth}>{member.acceptedTime || "N/A"}</div>
-                    <div className={columnWidth}>{member.username || "N/A"}</div>
-                    <div className={columnWidth}>{member.role || "N/A"}</div>
+                    <div className={columnWidth}>
+                      {member.acceptedTime || member.decisionDate || "N/A"}
+                    </div>
+                    <div className={columnWidth}>
+                      {member.username || member.userName || "N/A"}
+                    </div>
+                    <div className={columnWidth}>
+                      {member.role || "N/A"}
+                    </div>
 
                     {/* 액션 버튼 */}
                     {getActionConfig(idx, status, isMember, (id, key, value) =>

--- a/src/app/team/_components/MemberTables.tsx
+++ b/src/app/team/_components/MemberTables.tsx
@@ -1,12 +1,13 @@
 "use client";
-import React, {useState} from 'react';
+import React, { useEffect, useState } from "react";
 import MemberTableActionBtn from "@/app/team/_components/MemberTableActionBtn";
-import {TeamMemberTables} from "@/app/team/[page_type]/[team_id]/(member)/[member_type]/page";
+import { TeamMemberTables } from "@/app/team/[page_type]/[team_id]/(member)/[member_type]/page";
 import AlertModal from "@/components/common/Modal/AlertModal";
 import useModal from "@/hooks/useModal";
-import {MemberStatus} from "@/app/team/_type/teamPageMember";
-import {getActionConfig, submitBtnAction} from "@/app/team/_service/teamMemberService";
+import { MemberStatus } from "@/app/team/_type/teamPageMember";
+import { getActionConfig } from "@/app/team/_service/teamMemberService";
 import ErrorFallback from "@/components/error/ErrorFallback";
+import { useSubmit } from "@/hooks/form/useSubmit";
 
 // ✅ SelectedAction 인터페이스
 interface SelectedAction {
@@ -17,14 +18,7 @@ interface SelectedAction {
   label: string; // 선택된 액션의 라벨
 }
 
-// ✅ key -> 한글 변환 매핑 객체
-const actionLabels: Record<keyof MemberStatus, string> = {
-  approved: "승인",
-  removed: "강퇴",
-  reported: "신고",
-  written: "작성 완료",
-};
-
+// ✅ 기본 상태 정의
 const initialStatus: MemberStatus = {
   approved: null,
   removed: false,
@@ -32,83 +26,116 @@ const initialStatus: MemberStatus = {
   written: false,
 };
 
-const initialMember: SelectedAction = {
-  id: -1,
-  key: "approved",
-  name: "",
-  value: null,
-  label: "",
+// ✅ 엔드포인트 매핑 함수
+const getMemberActionEndpoint = (teamId: number, userId: number, action: keyof MemberStatus): string => {
+  const baseUrl = `/project/team/${teamId}/${userId}`;
+  const endpointMap: Record<keyof MemberStatus, string> = {
+    approved: `${baseUrl}/accept`, // 수락
+    removed: `${baseUrl}/export`,  // 내보내기
+    reported: `${baseUrl}/reject`, // 거절
+    written: `${baseUrl}/write`,   // 작성 완료 (현재 필요 없음)
+  };
+  return endpointMap[action];
 };
 
-const MemberTables: React.FC<TeamMemberTables> = ({type, data}) => {
+const MemberTables: React.FC<TeamMemberTables & { teamId: number }> = ({ type, data, teamId }) => {
   const isMember = type === "MEMBER";
   const columnWidth = isMember ? "w-1/5" : "w-1/4";
 
   // ✅ 모달 상태
   const { modal, openModal, closeModal } = useModal();
-  const [selectedAction, setSelectedAction] = useState<SelectedAction>(initialMember);
+  const [selectedAction, setSelectedAction] = useState<SelectedAction>({
+    id: -1,
+    key: "approved",
+    name: "",
+    value: null,
+    label: "",
+  });
 
-  // ✅ 멤버 상태
+  // ✅ 멤버 상태 관리
   const [memberStatus, setMemberStatus] = useState<Record<number, MemberStatus>>({});
 
-  // ✅ 멤버 상태 변경
-  const updateMemberStatus = ({ id, key, value }: SelectedAction) => {
-    setMemberStatus((prev) => ({
-      ...prev, [id]: {...prev[id], [key]: value,},}));
-  };
+  // ✅ 최초 데이터 로드 시 멤버 상태 초기화
+  useEffect(() => {
+    if (!data) return;
+    const initialMemberStatus: Record<number, MemberStatus> = {};
+    data.forEach((member) => {
+      initialMemberStatus[member.userId] = { ...initialStatus }; // 초기 상태 설정
+    });
+    setMemberStatus(initialMemberStatus);
+  }, [data]);
+
+  // ✅ useSubmit 훅 사용 (API 요청)
+  const endpoint = selectedAction.id !== -1 ? getMemberActionEndpoint(teamId, selectedAction.id, selectedAction.key) : ""
+  const { submit: updateMemberStatus, isLoading } = useSubmit({
+    endpoint: endpoint,
+    formatPayload: (data) => ({
+      id: 1,// data.id,
+      key: 2, // data.key,
+      value: 3, // data.value,
+    }),
+    onSuccess: () => {
+      // ✅ 상태 업데이트 반영
+      setMemberStatus((prev) => ({
+        ...prev,
+        [selectedAction.id]: { ...prev[selectedAction.id], [selectedAction.key]: selectedAction.value },
+      }));
+      console.log(`✅ ${selectedAction.name}(${selectedAction.key}) 상태 업데이트 완료!`);
+    },
+  });
 
   // ✅ 버튼 클릭 시 모달을 띄우도록 설정
-  const handleActionClick = ({ id, key, name, value }: Omit<SelectedAction, "label">) => {
-    const label = actionLabels[key] || key; // 변환된 한글 라벨 적용
-    setSelectedAction({ id, key, name, value, label }); // 선택된 액션 저장
-    openModal(); // 모달 열기
+  const handleActionClick = ({ id, key, name, value }: Omit<typeof selectedAction, "label">) => {
+    setSelectedAction({
+      id,
+      key,
+      name,
+      value,
+      label: key === "approved" ? "승인" : key === "removed" ? "강퇴" : "거절",
+    });
+    openModal();
   };
 
-  // ✅ 모달 확인 버튼 클릭 시 실제 상태 업데이트 수행
+  // ✅ 모달 확인 버튼 클릭 시 API 요청 실행
   const confirmAction = () => {
-    if (selectedAction.id !== -1) updateMemberStatus(selectedAction);
-    submitBtnAction();
+    if (selectedAction.id !== -1) {
+      updateMemberStatus({
+        id: selectedAction.id,
+        key: selectedAction.key,
+        value: selectedAction.value,
+      });
+    }
     closeModal();
   };
 
   return (
       <>
-        {data && data.length > 0 ? (
-            data.map((member, idx) => {
-              const status = memberStatus[idx] || initialStatus;
-              const date = member.decisionDate.slice(0, 10);
-              return (
-                  <div key={idx} className="flex text-center border-b last:border-none p-2 text-sm">
-                    <div className={columnWidth}>
-                      {date || "N/A"}
-                    </div>
-                    <div className={columnWidth}>
-                      {member.username || member.userName || "N/A"}
-                    </div>
-                    <div className={columnWidth}>
-                      {member.role || "N/A"}
-                    </div>
+        {(data ?? []).map((member, idx) => {
+          const status = memberStatus[member.userId] || initialStatus; // 기본값 적용
+          const date = member.decisionDate.slice(0, 10) || "N/A";
+          const username = member.username || member.userName || "N/A";
+          const role = member.role || "N/A";
+          const actions = getActionConfig(member.userId, status, isMember, (id, key, value) =>
+              handleActionClick({ id, key, name: member.username, value })
+          );
 
-                    {/* 액션 버튼 */}
-                    {getActionConfig(idx, status, isMember, (id, key, value) =>
-                        handleActionClick({ id, key, name: member.username, value })
-                    ).map((action, i) =>
-                        action?.className ? (
-                            <div key={i} className={`${columnWidth} ${action.className}`}>
-                              {action.label}
-                            </div>
-                        ) : (
-                            <div key={i} className={columnWidth}>
-                              <MemberTableActionBtn actions={[action]} />
-                            </div>
-                        )
-                    )}
-                  </div>
-              );
-            })
-        ) : (
-            <ErrorFallback message={"데이터 로딩중 오류가 발생했습니다."}/>
-        )}
+          return (
+              <div key={idx} className="flex text-center border-b last:border-none p-2 text-sm">
+                <div className={columnWidth}>{date}</div>
+                <div className={columnWidth}>{username}</div>
+                {type === "MEMBER" && <div className={columnWidth}>{role}</div>}
+                {type === "LEADER" && <div className={columnWidth}>0</div>}
+
+                {/* 액션 버튼 */}
+                {actions.map((action, i) => (
+                    <div key={i} className={columnWidth}>
+                      <MemberTableActionBtn actions={[action]} />
+                    </div>
+                ))}
+              </div>
+          );
+        })}
+        {!data?.length && <ErrorFallback message={"데이터 로딩 중 오류 발생"} />}
 
         {/* 모달 */}
         {modal && selectedAction && (
@@ -119,6 +146,7 @@ const MemberTables: React.FC<TeamMemberTables> = ({type, data}) => {
                 onConfirm={confirmAction}
                 buttonLabel="네"
                 isOpen={modal}
+                isLoading={isLoading}
             />
         )}
       </>

--- a/src/app/team/_components/MemberTables.tsx
+++ b/src/app/team/_components/MemberTables.tsx
@@ -5,7 +5,7 @@ import {TeamMemberTables} from "@/app/team/[page_type]/[team_id]/(member)/[membe
 import AlertModal from "@/components/common/Modal/AlertModal";
 import useModal from "@/hooks/useModal";
 import {MemberStatus} from "@/app/team/_type/teamPageMember";
-import {getActionConfig} from "@/app/team/_service/teamPageMemberService";
+import {getActionConfig, submitBtnAction} from "@/app/team/_service/teamMemberService";
 import ErrorFallback from "@/components/error/ErrorFallback";
 
 // ✅ SelectedAction 인터페이스
@@ -67,6 +67,7 @@ const MemberTables: React.FC<TeamMemberTables> = ({type, data}) => {
   // ✅ 모달 확인 버튼 클릭 시 실제 상태 업데이트 수행
   const confirmAction = () => {
     if (selectedAction.id !== -1) updateMemberStatus(selectedAction);
+    submitBtnAction();
     closeModal();
   };
 

--- a/src/app/team/_components/MemberTables.tsx
+++ b/src/app/team/_components/MemberTables.tsx
@@ -79,7 +79,7 @@ const MemberTables: React.FC<TeamMemberTables> = ({type, data}) => {
               return (
                   <div key={idx} className="flex text-center border-b last:border-none p-2 text-sm">
                     <div className={columnWidth}>{member.acceptedTime || "N/A"}</div>
-                    <div className={columnWidth}>{member.username}</div>
+                    <div className={columnWidth}>{member.username || "N/A"}</div>
                     <div className={columnWidth}>{member.role || "N/A"}</div>
 
                     {/* 액션 버튼 */}

--- a/src/app/team/_components/MemberTables.tsx
+++ b/src/app/team/_components/MemberTables.tsx
@@ -75,11 +75,11 @@ const MemberTables: React.FC<TeamMemberTables> = ({type, data}) => {
         {data && data.length > 0 ? (
             data.map((member, idx) => {
               const status = memberStatus[idx] || initialStatus;
-
+              const date = member.decisionDate.slice(0, 10);
               return (
                   <div key={idx} className="flex text-center border-b last:border-none p-2 text-sm">
                     <div className={columnWidth}>
-                      {member.acceptedTime || member.decisionDate || "N/A"}
+                      {date || "N/A"}
                     </div>
                     <div className={columnWidth}>
                       {member.username || member.userName || "N/A"}

--- a/src/app/team/_service/teamMemberService.ts
+++ b/src/app/team/_service/teamMemberService.ts
@@ -81,7 +81,3 @@ export const transformTeamData = (
 
   return [];
 };
-
-export const submitBtnAction = () => {
-  console.log("버튼 클릭")
-}

--- a/src/app/team/_service/teamMemberService.ts
+++ b/src/app/team/_service/teamMemberService.ts
@@ -1,6 +1,7 @@
 import {MemberStatus, MentoringMemberResponse, ProjectMember} from "@/app/team/_type/teamPageMember";
 import {ActionBtn} from "@/app/team/_components/MemberTableActionBtn";
 import ActionButtonClass from "@/app/team/_service/ActionButtonClass";
+import {isMentoringMember, isProjectMember} from "@/app/team/_service/teamTypeGuard";
 
 export const getActionConfig = (
     id: number,
@@ -38,17 +39,6 @@ export const getActionConfig = (
 
   return actions;
 }
-
-// ✅ 타입 가드 함수
-// ✅ 프로젝트 멤버인지 확인
-export const isProjectMember = (data: unknown): data is ProjectMember[] => {
-  return Array.isArray(data) && data.every(member => "participationId" in member);
-};
-
-// ✅ 멘토링 멤버인지 확인 (리더 or 일반 멤버)
-export const isMentoringMember = (data: unknown): data is MentoringMemberResponse => {
-  return typeof data === "object" && data !== null && "authority" in data;
-};
 
 // ✅ 데이터 변환 함수
 export const transformTeamData = (
@@ -91,3 +81,7 @@ export const transformTeamData = (
 
   return [];
 };
+
+export const submitBtnAction = () => {
+  console.log("버튼 클릭")
+}

--- a/src/app/team/_service/teamMemberService.ts
+++ b/src/app/team/_service/teamMemberService.ts
@@ -84,8 +84,13 @@ export const transformTeamData = (
 };
 
 // ✅ 엔드포인트 매핑 함수
-export const getMemberActionEndpoint = (teamId: number, userId: number, action: keyof MemberStatus): string => {
-  const baseUrl = `/project/team/${teamId}/${userId}`;
+export const getMemberActionEndpoint = (
+    pageType: string,
+    teamId: string,
+    userId: number,
+    action: keyof MemberStatus
+): string => {
+  const baseUrl = `/${pageType}/team/${teamId}/${userId}`;
   const endpointMap: Record<keyof MemberStatus, string> = {
     approved: `${baseUrl}/accept`, // 수락
     removed: `${baseUrl}/export`,  // 내보내기

--- a/src/app/team/_service/teamPageMemberService.ts
+++ b/src/app/team/_service/teamPageMemberService.ts
@@ -51,31 +51,22 @@ export const isMentoringMember = (data: unknown): data is MentoringMemberRespons
 };
 
 // ✅ 데이터 변환 함수
-// ✅ API 응답을 통합된 TeamMember[] 형태로 변환
 export const transformTeamData = (
     data: MentoringMemberResponse | ProjectMember[] | undefined
 ): ProjectMember[] => {
-  if (!data) {
-    console.log("Data is undefined, returning empty array");
-    return [];
-  }
+  // ✅ 데이터가 없는경우 빈 배열 반환
+  if (!data) return [];
 
-  if (isProjectMember(data)) {
-    console.log("✅ ProjectMember detected, returning as is: ", data);
-    return data;  // ✅ 프로젝트 데이터 그대로 반환
-  }
+  // ✅ 프로젝트 데이터 그대로 반환
+  if (isProjectMember(data)) return data;
 
   if (isMentoringMember(data)) {
-    console.log("✅ MentoringMember detected, transforming data...");
-
-    // ✅ members 필드는 data.details.members에 존재!
     const details = (data as MentoringMemberResponse).details;
-    console.log(`details: ${details}`)
+
     // ✅ `details`가 객체인지 확인 후 `members`에 접근
-    if (!("details" in data) || typeof data.details !== "object" || !Array.isArray(data.details.members)) {
-      console.log("❌ data.details.members is not an array, returning empty array");
-      return [];
-    }
+    const hasNoDetails = !("details" in data) || typeof data.details !== "object";
+    const hasNoMembersArray = !Array.isArray(data.details.members);
+    if (hasNoDetails || hasNoMembersArray) return [];
 
     return details.members.map(member => ({
       type: "PROJECT",
@@ -98,6 +89,5 @@ export const transformTeamData = (
     }));
   }
 
-  console.log("❌ Data does not match any type, returning empty array");
   return [];
 };

--- a/src/app/team/_service/teamPageMemberService.ts
+++ b/src/app/team/_service/teamPageMemberService.ts
@@ -1,4 +1,4 @@
-import {MemberStatus} from "@/app/team/_type/teamPageMember";
+import {MemberStatus, MentoringTeamLeader, MentoringTeamMember, ProjectMember} from "@/app/team/_type/teamPageMember";
 import {ActionBtn} from "@/app/team/_components/MemberTableActionBtn";
 import ActionButtonClass from "@/app/team/_service/ActionButtonClass";
 
@@ -38,3 +38,33 @@ export const getActionConfig = (
 
   return actions;
 }
+
+// ✅ 타입 가드 함수
+export const isProjectMember = (data: unknown): data is ProjectMember[] => {
+  return Array.isArray(data) && data.every(member => "participationId" in member);
+};
+
+export const isMentoringLeader = (data: unknown): data is MentoringTeamLeader => {
+  return (data as MentoringTeamLeader)?.authority === "LEADER";
+};
+
+export const isMentoringMember = (data: unknown): data is MentoringTeamMember => {
+  return (data as MentoringTeamMember)?.authority === "MEMBER";
+};
+
+// ✅ 데이터 변환 함수
+export const transformTeamData = (
+    data: MentoringTeamLeader | MentoringTeamMember | ProjectMember[] | undefined
+): ProjectMember[] => {
+  if (!data) return []; // 데이터가 없을 경우 빈 배열 반환
+
+  if (isProjectMember(data)) {
+    return data;
+  } else if (isMentoringLeader(data)) {
+    return data.details.members;
+  } else if (isMentoringMember(data)) {
+    return data.details;
+  }
+
+  return [];
+};

--- a/src/app/team/_service/teamTypeGuard.ts
+++ b/src/app/team/_service/teamTypeGuard.ts
@@ -1,0 +1,11 @@
+// ✅ 프로젝트 멤버인지 확인
+import {MentoringMemberResponse, ProjectMember} from "@/app/team/_type/teamPageMember";
+
+export const isProjectMember = (data: unknown): data is ProjectMember[] => {
+  return Array.isArray(data) && data.every(member => "participationId" in member);
+};
+
+// ✅ 멘토링 멤버인지 확인 (리더 or 일반 멤버)
+export const isMentoringMember = (data: unknown): data is MentoringMemberResponse => {
+  return typeof data === "object" && data !== null && "authority" in data;
+};

--- a/src/app/team/_type/teamPageInfo.ts
+++ b/src/app/team/_type/teamPageInfo.ts
@@ -1,6 +1,7 @@
 export interface TeamPageInfo {
   // 권한
   authority: string;
+  userRole: string;
 
   // dto
   dto: {

--- a/src/app/team/_type/teamPageMember.ts
+++ b/src/app/team/_type/teamPageMember.ts
@@ -1,4 +1,4 @@
-// 멤버의 상태 (MemberTables)
+// ✅ 멤버 상태 (MemberTables)
 export interface MemberStatus {
   approved: boolean | null; // 수락 여부
   removed: boolean; // 내보내기 여부
@@ -6,74 +6,59 @@ export interface MemberStatus {
   written: boolean; // 작성 여부
 }
 
-// 공통 인터페이스
-interface CommonMember<T> {
-  status: number;
-  code: string;
-  message: string;
-  data: T;
+// ✅ 공통 멤버 인터페이스 (멘토링 & 프로젝트 멤버 포함)
+export interface BaseMember {
+  userId: number;
+  role: "MENTOR" | "MENTEE" | string;
 }
 
-// 리더용 반환데이터 구조
-interface MentoringTeamLeaderData {
+// ✅ 멘토링 멤버 인터페이스
+export interface MentoringMember extends BaseMember {
+  type: "MENTORING";
+  username: string;
+  acceptedTime: string;
+  status: "ACCEPTED" | "PENDING";
+  isLogined: boolean;
+  isDeleted: boolean;
+}
+
+// ✅ 프로젝트 멤버 인터페이스
+export interface ProjectMember extends BaseMember {
+  // 타입 오류 방지를 위해 임시로 선언
+  acceptedTime: string;
+  username: string;
+  
+  type: "PROJECT";
+  userName: string;
+  participationId: number;
+  projectTeamId: number;
+  participationStatus: string;
+  isDeleted: boolean;
+  isExport: boolean;
+  decisionDate: string;
+  recruitCategory: string;
+  reportingCnt: number;
+  isLoginUser: boolean;
+  isReported: boolean;
+  isReviewed: boolean;
+}
+
+// ✅ API 응답에서 필요한 데이터만 추출
+export interface MentoringTeamLeader {
   teamId: number;
   authority: "LEADER";
   details: {
-    members: {
-      acceptedTime: string;
-      userId: number;
-      username: string;
-      role: "MENTOR" | "MENTEE";
-      status: "ACCEPTED" | "PENDING";
-      isLogined: boolean;
-      isDeleted: boolean;
-    }[];
-    participations: {
-      participatedTime: string;
-      userId: number;
-      username: string;
-      reportingCnt: number;
-      status: "ACCEPTED" | "PENDING";
-    }[];
+    members: MentoringMember[];
   };
 }
 
-
-// 멤버용 반환데이터 구조
-interface MentoringTeamMemberData {
+export interface MentoringTeamMember {
   teamId: number;
-  authority: "CREW";
+  authority: "MEMBER";
   details: {
-    acceptedTime: string;
-    userId: number;
-    username: string;
-    role: "MENTOR" | "MENTEE";
-    status: "ACCEPTED" | "PENDING";
-    isLogined: boolean;
-    isDeleted: boolean;
-  }[];
+    members: MentoringMember[];
+  };
 }
 
-// 프로젝트 멤버
-export interface ProjectMemberData {
-  "participationId": number,
-  "userId": number,
-  "projectTeamId": number,
-  "participationStatus": string,
-  "isDeleted": boolean,
-  "isExport": boolean,
-  "decisionDate": string,
-  "role": string,
-  "recruitCategory": string,
-  "reportingCnt": number,
-  "isLoginUser": boolean,
-  "isReported": boolean,
-  "isReviewed": boolean
-}
-
-// 멘토링 리더 / 멤버
-export type MentoringTeamLeader = CommonMember<MentoringTeamLeaderData>;
-export type MentoringTeamMember = CommonMember<MentoringTeamMemberData>;
-
-// 프로젝트 멤버
-export type ProjectMember = CommonMember<ProjectMemberData[]>
+// ✅ 최종 API 응답 데이터 타입 (프로젝트와 멘토링 통합)
+export type MentoringMemberResponse = MentoringTeamLeader | MentoringTeamMember;

--- a/src/components/common/Modal/AlertModal.tsx
+++ b/src/components/common/Modal/AlertModal.tsx
@@ -9,6 +9,7 @@ interface AlertModalProps {
   message: string;
   buttonLabel?: string;
   ConfirmButonColor?: string;
+  isLoading?: boolean;
 }
 
 const AlertModal = ({
@@ -19,6 +20,7 @@ const AlertModal = ({
   buttonLabel = "확인",
   title,
   ConfirmButonColor = "bg-primary",
+  isLoading = false,
 }: AlertModalProps) => {
   const buttonHover = "hover:bg-opacity-85 transition-colors";
   const buttonCommonStyle = "py-2 rounded-lg w-full";
@@ -34,6 +36,7 @@ const AlertModal = ({
         <button
           className={`${buttonCommonStyle} text-white  ${ConfirmButonColor} ${buttonHover}`}
           onClick={onConfirm}
+          disabled={isLoading}
         >
           {buttonLabel}
         </button>


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
> ### 멤버 페이지 내 서비스로직 분리 (b449f03fa3dd5943f346c3bced3b934678a84e5a)
- 서비스 로직을 별도의 유틸 파일로 분리하였습니다.
- 멘토링 팀과 프로젝트 팀의 데이터를 구분하기 위한 타입 가드 함수를 추가하고, 기존 로직을 개선했습니다.

분리된 함수
- isProjectMember (프로젝트 멤버인지 확인)
- isMentoringMember (멘토링 멤버인지 확인)

> ###  멤버 테이블 내 날짜 포맷 (bd23e23a1202a51b59c52a86dafcd2aa86a8a3bc)
- 멘토링 / 프로젝트 멤버 페이지 내 날짜(신청날짜)를 yyyy-mm-dd 형식으로 변경하였습니다.

> ### 버튼(내보내기, 신고, 작성, 수락, 거절) 클릭 시 API 연동 (ea4acd492efe4288eb40789227c8070d739ad1de)
- 버튼 클릭 시 서버에 요청을 보내는 로직을 추가했습니다.
- 엔드포인트를 동적으로 생성하여 API 를 요청하는 `getMemberActionEndpoint`함수가 추가되었습니다.
   - 수락 - `approved: ${baseUrl}/accept`
   - 내보내기(추방) - `removed: ${baseUrl}/export`
   - 거절 - `reported: ${baseUrl}/reject`
   - 작성(리뷰) - `written: ${baseUrl}/write`
```javaScript
const baseUrl = `/${pageType}/team/${teamId}/${userId}`; // example : /project/team/43/3
```
- `useSubmit`내 `formatPayload` 에서 id 값을 문자열로 변환하여 API 요청을 처리하도록 타입캐스팅을 진행하였습니다.
- API 요청 성공 후, 멤버 상태를 업데이트하여 변경 사항을 UI에 반영하는 `updateMemberStatusState ` 함수가 추가되었습니다.

<br>

## 버그 픽스
> ### 게시글 없을경우 ~ 출력되던 오류 수정 (d04a7fde8a66659f4e48b6dcb9ef118e12089319)
- 게시글이 존재하지 않을 경우 물결 기호(~)만 출력되던 버그를 수정하였습니다.
- 게시글이 존재하지 않을 경우 `게시글이 존재하지 않습니다.` 텍스트가 출력되고 게시글 작성 페이지로 이동하는 링크를 추가했습니다.

> ### 사용자 권한이 리더(오너)일 경우 팀 멤버 내 신청내역이 출력되도록 수정 (bc0fe63852bdc20e0214a509febde030c0377bfc)
- 사용자가 프로젝트/멘토링 의 리더(오너)일 경우 신청내역이 출력되지 않던 문제가 수정되었습니다.

> ### 수락 거절 버튼 위치가 불일치 하던 문제 수정 (31b042938bc181aae7e653ce1cac36c7cff96105)
- 수락 거절 버튼의 간격을 조절하여 UI 위치가 불일치 하던 문제를 수정했습니다.